### PR TITLE
fix: run lint immediately after startup.

### DIFF
--- a/src/driver/joplin/index.ts
+++ b/src/driver/joplin/index.ts
@@ -22,5 +22,9 @@ export class Joplin {
     );
 
     await joplin.contentScripts.onMessage(SCRIPT_ID, this.handleRequest.bind(this));
+    
+    // run lint immediately after starting
+    const note = await joplin.workspace.selectedNote();
+    await this.handleRequest({event: 'lint', payload: { text: note.body }});
   }
 }


### PR DESCRIPTION
Thanks for a very nice plugin!
I fixed to run lint immediately after startup.
Before the commit, lint was not executed unless another note was selected or the note was edited.